### PR TITLE
Make deps on feature semver not on bugfix, make getrandom js feature on wasm only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,15 @@ name = "dkls23"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-k256 = { version = "0.13.1", features = ["serde"] }
-bitcoin_hashes = "0.12.0"
-sha3 = "0.10.8"
-rand = "0.8.5"
-getrandom = { version = "0.2.10", features = ["js"] }
-hex = "0.4.3"
-serde = { version = "1.0.188", features = ["derive"] }
+k256 = { version = "0.13", features = ["serde"] }
+bitcoin_hashes = "0.13"
+sha3 = "0.10"
+rand = "0.8"
+getrandom = "0.2"
+hex = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]


### PR DESCRIPTION
# Description

This PR modifies the `Cargo.toml` file to conditionally enable the "js" feature for the "getrandom" crate when compiling for any WebAssembly environment. Please find the details below.

Closes #14 and closes #15 

## Features

- [X] Check if dependencies follow semver and move deps to feature level.
- [X] Conditional compilation for "getrandom" crate in WebAssembly environments.

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation
- [X] New and existing tests pass locally with my changes

## Observations

The `getrandom` crate is a popular library for generating random numbers. However, when compiling for WebAssembly, it requires the "js" feature to be enabled. This PR modifies the `Cargo.toml` file to conditionally enable this feature only when compiling for WebAssembly, making it more flexible for different build environments [Source 0](https://doc.rust-lang.org/rust-by-example/hello/print/fmt.html), [Source 2](https://doc.rust-lang.org/std/fmt/), [Source 6](https://github.com/rust-lang/rfcs), [Source 14](https://refactoring.guru/design-patterns/template-method/rust/example).