### PR TITLE
Important correction done in multiplication.rs and ot/extension.rs

### DIFF
--- a/src/protocols/re_key.rs
+++ b/src/protocols/re_key.rs
@@ -103,15 +103,9 @@ pub fn re_key(
 
     // These will store the result of initialization for each party.
     let mut all_mul_receivers: Vec<BTreeMap<u8, MulReceiver>> =
-        vec![
-            BTreeMap::new();
-            parameters.share_count as usize
-        ];
+        vec![BTreeMap::new(); parameters.share_count as usize];
     let mut all_mul_senders: Vec<BTreeMap<u8, MulSender>> =
-        vec![
-            BTreeMap::new();
-            parameters.share_count as usize
-        ];
+        vec![BTreeMap::new(); parameters.share_count as usize];
 
     for receiver in 1..=parameters.share_count {
         for sender in 1..=parameters.share_count {

--- a/src/protocols/refresh.rs
+++ b/src/protocols/refresh.rs
@@ -902,7 +902,8 @@ mod tests {
         }
 
         // Phase 2
-        let mut correction_values: Vec<Scalar> = Vec::with_capacity(parameters.share_count as usize);
+        let mut correction_values: Vec<Scalar> =
+            Vec::with_capacity(parameters.share_count as usize);
         let mut proofs_commitments: Vec<ProofCommitment> =
             Vec::with_capacity(parameters.share_count as usize);
         let mut zero_kept_2to3: Vec<BTreeMap<u8, KeepInitZeroSharePhase2to3>> =
@@ -1189,7 +1190,8 @@ mod tests {
         }
 
         // Phase 2
-        let mut correction_values: Vec<Scalar> = Vec::with_capacity(parameters.share_count as usize);
+        let mut correction_values: Vec<Scalar> =
+            Vec::with_capacity(parameters.share_count as usize);
         let mut proofs_commitments: Vec<ProofCommitment> =
             Vec::with_capacity(parameters.share_count as usize);
         let mut kept_2to3: Vec<BTreeMap<u8, KeepRefreshPhase2to3>> =


### PR DESCRIPTION
# Description

Important correction: the multiplication protocol had a very serious problem. The elements of the vectors `z_tilde` and `z_hat` were always the same, but they shouldn't be correlated. This happened because we have to call the OT extension protocol as the sender multiple times, using the same values chosen by the receiver in each iteration. In the process, we naturally have to change the random oracle, but this was not being done.

In order to fix this, we have to use a unique salt when hashing in these different iterations. To implement this, I moved the multiple executions during multiplication to the OT extension protocol itself (in the file ot/extension.rs). Now, to execute the OT protocol you must enter the number of times you want to reapply it (parametrized by the new `ot_width` variable) and, instead of supplying a single correlation vector, you supply a vector of correlation vectors.

Small change: In the file dkg.rs, I changed the type of `commited_points` to a `BTreeMap`. This removes the order dependency on the vector `proofs_commitments`, which was not expected to exist.

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my feat/fix is effective and works
- [X] New and existing tests pass locally with my changes

## Observations

Small changes in other files due to cargo fmt.