### PR TITLE
Calculate Recovery id directly from x and y coords instead of guessing it

### DIFF
--- a/src/protocols/signing.rs
+++ b/src/protocols/signing.rs
@@ -1042,8 +1042,15 @@ mod tests {
                 + (secret_key * Scalar::reduce(U256::from_be_hex(&expected_x_coord))));
         let expected_signature = hex::encode(expected_signature_as_scalar.to_bytes().as_slice());
 
+        // Calculate the expected recovery id
+        let half_order = Scalar::reduce(Secp256k1::ORDER >> 1);
+        let is_x_reduced = expected_signature_as_scalar > half_order;
+        let is_y_odd = total_instance_point.to_encoded_point(false).y().unwrap()[31] & 1 == 1;
+        let expected_rec_id = RecoveryId::new(is_y_odd, is_x_reduced);
+
         // We compare the results.
         assert_eq!(signature.0, expected_signature);
+        assert_eq!(signature.1, expected_rec_id.into());
     }
 
     /// Tests DKG and signing together. The main purpose is to


### PR DESCRIPTION
Guessing the `RecoveryId` with `trial_recovery_from_prehash` was leading to signature invalidations in singing phase 4 and breaking the `test_against_ecdsa` as stated in #31.

# Solution
In order to solve this issue, we are now calculating the `RecoveryId` directly from x and y, as [suggested](https://github.com/0xCarbon/DKLs23/issues/31#issuecomment-2247048929). 

Please, check [#31] to read the .

## Fixes

- [X] `test_against_ecdsa`: In order to validate the fix, I have run this test 100 times with:
```bash
for i in {1..100}
do
   cargo test protocols::signing::tests::test_signing_against_ecdsa -- --nocapture --exact
done
```

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [x] ~I have made corresponding changes to the documentation~: doesn't apply
- [X] ~I have added tests that prove my feat/fix is effective and works~: doesn't apply
- [X] New and existing tests pass locally with my changes
