### PR TITLE
chore: modernize dependency stack and resolve deprecations (issue #47)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,17 @@ repository = "https://github.com/0xCarbon/DKLs23"
 readme = "README.md"
 
 [dependencies]
-k256 = { version = "0.13", features = ["serde"] }
+k256 = { version = "0.14.0-rc.7", features = ["serde"] }
 bitcoin_hashes = "0.16"
 sha3 = "0.10"
-rand = "0.8"
-getrandom = "0.3"
+rand = "0.10"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.12"
 zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-version = "0.3"
+version = "0.4"
 features = ["wasm_js"]
 
 [features]

--- a/src/protocols/derivation.rs
+++ b/src/protocols/derivation.rs
@@ -110,7 +110,7 @@ impl DerivData {
             ));
         }
 
-        let tweak = Scalar::reduce(number_for_tweak);
+        let tweak = Scalar::reduce(&number_for_tweak);
         let chain_code: ChainCode = hmac_bytes[32..]
             .try_into()
             .expect("Half of hmac is guaranteed to be 32 bytes!");
@@ -309,7 +309,7 @@ mod tests {
     use crate::utilities::rng;
     use hex;
     use k256::elliptic_curve::Field;
-    use rand::Rng;
+    use rand::RngExt;
     use std::collections::BTreeMap;
 
     /// Tests if the method `derive_from_path` from [`DerivData`]
@@ -321,7 +321,7 @@ mod tests {
     fn test_derivation() {
         // The following values were calculated at random with: https://bitaps.com/bip32.
         // You should test other values as well.
-        let sk = Scalar::reduce(U256::from_be_hex(
+        let sk = Scalar::reduce(&U256::from_be_hex(
             "6728f18f7163f7a0c11cc0ad53140afb4e345d760f966176865a860041549903",
         ));
         let pk = (AffinePoint::GENERATOR * sk).to_affine();
@@ -372,8 +372,8 @@ mod tests {
     /// the signing protocol after being derived.
     #[test]
     fn test_derivation_and_signing() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
@@ -381,8 +381,8 @@ mod tests {
         }; // You can fix the parameters if you prefer.
 
         // We use the re_key function to quickly sample the parties.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         // DERIVATION
@@ -406,7 +406,7 @@ mod tests {
 
         // SIGNING (as in test_signing)
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.

--- a/src/protocols/dkg.rs
+++ b/src/protocols/dkg.rs
@@ -51,9 +51,9 @@ use std::collections::BTreeMap;
 
 use hex;
 use k256::elliptic_curve::Field;
-use k256::{elliptic_curve::sec1::ToEncodedPoint, AffinePoint, Scalar};
+use k256::{elliptic_curve::sec1::ToSec1Point, AffinePoint, Scalar};
 
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
@@ -441,7 +441,7 @@ pub fn phase2(
     // Initialization - BIP-32.
 
     // Each party samples a random auxiliary chain code.
-    let aux_chain_code: ChainCode = rng::get_rng().gen();
+    let aux_chain_code: ChainCode = rng::get_rng().random();
     let (cc_commitment, cc_salt) = commits::commit(&aux_chain_code);
 
     let bip_keep = UniqueKeepDerivationPhase2to3 {
@@ -891,7 +891,7 @@ pub fn phase4(
 #[must_use]
 pub fn compute_eth_address(pk: &AffinePoint) -> String {
     // Serialize the public key in uncompressed form
-    let uncompressed_pk = pk.to_encoded_point(false);
+    let uncompressed_pk = pk.to_sec1_point(false);
 
     // Compute the Keccak256 hash of the serialized public key
     // Skip the "04" SEC-1 prefix, see: https://www.secg.org/sec1-v2.pdf sec 3.3.3 page 11
@@ -929,7 +929,7 @@ mod tests {
     use super::*;
     use k256::elliptic_curve::ops::Reduce;
     use k256::U256;
-    use rand::Rng;
+    use rand::RngExt;
 
     // DISTRIBUTED KEY GENERATION (without initializations)
 
@@ -946,7 +946,7 @@ mod tests {
             threshold: 2,
             share_count: 2,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Phase 1 (Steps 1 and 2)
         let p1_phase1 = step2(&parameters, &step1(&parameters)); //p1 = Party 1
@@ -983,14 +983,14 @@ mod tests {
     /// t and n are small random values.
     #[test]
     fn test_dkg_random() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
             share_count: threshold + offset,
         }; // You can fix the parameters if you prefer.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Phase 1 (Steps 1 and 2)
         // Matrix of polynomial points
@@ -1047,7 +1047,7 @@ mod tests {
             threshold: 2,
             share_count: 2,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // We will define the fragments directly
         let p1_poly_fragments = vec![Scalar::from(1u32), Scalar::from(3u32)];
@@ -1091,7 +1091,7 @@ mod tests {
             threshold: 2,
             share_count: 2,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // We will define the fragments directly
         let p1_poly_fragments = vec![Scalar::from(12u32), Scalar::from(2u32)];
@@ -1136,7 +1136,7 @@ mod tests {
             threshold: 3,
             share_count: 5,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // We will define the fragments directly
         let poly_fragments = vec![
@@ -1234,14 +1234,14 @@ mod tests {
     /// The correctness of the protocol is verified on `test_dkg_and_signing`.
     #[test]
     fn test_dkg_initialization() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
             share_count: threshold + offset,
         }; // You can fix the parameters if you prefer.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Each party prepares their data for this DKG.
         let mut all_data: Vec<SessionData> = Vec::with_capacity(parameters.share_count as usize);
@@ -1420,7 +1420,7 @@ mod tests {
     fn test_compute_eth_address() {
         // You should test different values using, for example,
         // https://www.rfctools.com/ethereum-address-test-tool/.
-        let sk = Scalar::reduce(U256::from_be_hex(
+        let sk = Scalar::reduce(&U256::from_be_hex(
             "0249815B0D7E186DB61E7A6AAD6226608BB1C48B309EA8903CAB7A7283DA64A5",
         ));
         let pk = (AffinePoint::GENERATOR * sk).to_affine();

--- a/src/protocols/re_key.rs
+++ b/src/protocols/re_key.rs
@@ -13,7 +13,7 @@ use k256::elliptic_curve::Field;
 use k256::{AffinePoint, Scalar};
 
 use crate::utilities::rng;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::protocols::derivation::{ChainCode, DerivData};
 use crate::protocols::dkg::compute_eth_address;
@@ -50,7 +50,7 @@ pub fn re_key(
     let mut polynomial: Vec<Scalar> = Vec::with_capacity(parameters.threshold as usize);
     polynomial.push(*secret_key);
     for _ in 1..parameters.threshold {
-        polynomial.push(Scalar::random(rng::get_rng()));
+        polynomial.push(Scalar::random(&mut rng::get_rng()));
     }
 
     // Zero shares.
@@ -67,7 +67,7 @@ pub fn re_key(
         let mut seeds_with_lower_index: Vec<zero_shares::Seed> =
             Vec::with_capacity((parameters.share_count - lower_index) as usize);
         for _ in (lower_index + 1)..=parameters.share_count {
-            let seed = rng::get_rng().gen::<zero_shares::Seed>();
+            let seed = rng::get_rng().random::<zero_shares::Seed>();
             seeds_with_lower_index.push(seed);
         }
         common_seeds.push(seeds_with_lower_index);
@@ -125,8 +125,8 @@ pub fn re_key(
             let mut seeds0: Vec<HashOutput> = Vec::with_capacity(ot::extension::KAPPA as usize);
             let mut seeds1: Vec<HashOutput> = Vec::with_capacity(ot::extension::KAPPA as usize);
             for _ in 0..ot::extension::KAPPA {
-                seeds0.push(rng::get_rng().gen::<HashOutput>());
-                seeds1.push(rng::get_rng().gen::<HashOutput>());
+                seeds0.push(rng::get_rng().random::<HashOutput>());
+                seeds1.push(rng::get_rng().random::<HashOutput>());
             }
 
             // Sender: Sample the correlation and choose the correct seed.
@@ -134,7 +134,7 @@ pub fn re_key(
             let mut correlation: Vec<bool> = Vec::with_capacity(ot::extension::KAPPA as usize);
             let mut seeds: Vec<HashOutput> = Vec::with_capacity(ot::extension::KAPPA as usize);
             for i in 0..ot::extension::KAPPA {
-                let current_bit: bool = rng::get_rng().gen();
+                let current_bit: bool = rng::get_rng().random();
                 if current_bit {
                     seeds.push(seeds1[i as usize]);
                 } else {
@@ -151,7 +151,7 @@ pub fn re_key(
             let mut public_gadget: Vec<Scalar> =
                 Vec::with_capacity(ot::extension::BATCH_SIZE as usize);
             for _ in 0..ot::extension::BATCH_SIZE {
-                public_gadget.push(Scalar::random(rng::get_rng()));
+                public_gadget.push(Scalar::random(&mut rng::get_rng()));
             }
 
             // We finish the initialization.
@@ -175,7 +175,7 @@ pub fn re_key(
     // We use the chain code given or we sample a new one.
     let chain_code = match option_chain_code {
         Some(cc) => cc,
-        None => rng::get_rng().gen::<ChainCode>(),
+        None => rng::get_rng().random::<ChainCode>(),
     };
 
     // We create the parties.

--- a/src/protocols/refresh.rs
+++ b/src/protocols/refresh.rs
@@ -163,7 +163,7 @@ impl Party {
             Vec::with_capacity(self.parameters.threshold as usize);
         secret_polynomial.push(Scalar::ZERO);
         for _ in 1..self.parameters.threshold {
-            secret_polynomial.push(Scalar::random(rng::get_rng()));
+            secret_polynomial.push(Scalar::random(&mut rng::get_rng()));
         }
 
         step2(&self.parameters, &secret_polynomial)
@@ -565,7 +565,7 @@ impl Party {
             Vec::with_capacity(self.parameters.threshold as usize);
         secret_polynomial.push(Scalar::ZERO);
         for _ in 1..self.parameters.threshold {
-            secret_polynomial.push(Scalar::random(rng::get_rng()));
+            secret_polynomial.push(Scalar::random(&mut rng::get_rng()));
         }
 
         step2(&self.parameters, &secret_polynomial)
@@ -942,7 +942,7 @@ mod tests {
     use crate::protocols::signing::*;
     use crate::protocols::Parameters;
 
-    use rand::Rng;
+    use rand::RngExt;
 
     /// Tests if the complete refresh protocol generates parties
     /// still capable of running the signing protocol.
@@ -950,8 +950,8 @@ mod tests {
     /// In this case, parties are sampled via the [`re_key`] function.
     #[test]
     fn test_refresh_complete() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
@@ -959,13 +959,13 @@ mod tests {
         }; // You can fix the parameters if you prefer.
 
         // We use the re_key function to quickly sample the parties.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         // REFRESH (it follows test_dkg_initialization closely)
 
-        let refresh_sid = rng::get_rng().gen::<[u8; 32]>();
+        let refresh_sid = rng::get_rng().random::<[u8; 32]>();
 
         // Phase 1
         let mut dkg_1: Vec<Vec<Scalar>> = Vec::with_capacity(parameters.share_count as usize);
@@ -1106,7 +1106,7 @@ mod tests {
 
         // SIGNING (as in test_signing)
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.
@@ -1243,8 +1243,8 @@ mod tests {
     /// In this case, parties are sampled via the [`re_key`] function.
     #[test]
     fn test_refresh() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
@@ -1252,13 +1252,13 @@ mod tests {
         }; // You can fix the parameters if you prefer.
 
         // We use the re_key function to quickly sample the parties.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         // REFRESH (faster version)
 
-        let refresh_sid = rng::get_rng().gen::<[u8; 32]>();
+        let refresh_sid = rng::get_rng().random::<[u8; 32]>();
 
         // Phase 1
         let mut dkg_1: Vec<Vec<Scalar>> = Vec::with_capacity(parameters.share_count as usize);
@@ -1376,7 +1376,7 @@ mod tests {
 
         // SIGNING (as in test_signing)
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.

--- a/src/protocols/signing.rs
+++ b/src/protocols/signing.rs
@@ -27,8 +27,7 @@
 
 use k256::ecdsa::RecoveryId;
 use k256::elliptic_curve::scalar::IsHigh;
-use k256::elliptic_curve::sec1::ToEncodedPoint;
-use k256::elliptic_curve::ScalarPrimitive;
+use k256::elliptic_curve::sec1::ToSec1Point;
 use k256::elliptic_curve::{bigint::Encoding, ops::Reduce, point::AffineCoordinates, Curve, Field};
 use k256::{AffinePoint, ProjectivePoint, Scalar, Secp256k1, U256};
 use serde::{Deserialize, Serialize};
@@ -205,8 +204,8 @@ impl Party {
         }
 
         // Step 5 - We sample our secret data.
-        let instance_key = Scalar::random(rng::get_rng());
-        let inversion_mask = Scalar::random(rng::get_rng());
+        let instance_key = Scalar::random(&mut rng::get_rng());
+        let inversion_mask = Scalar::random(&mut rng::get_rng());
 
         let instance_point = (AffinePoint::GENERATOR * instance_key).to_affine();
 
@@ -638,11 +637,11 @@ impl Party {
         let u = (unique_kept.instance_key * first_sum_u_v) + second_sum_u;
         let v = (unique_kept.key_share * first_sum_u_v) + second_sum_v;
 
-        let x_coord = hex::encode(total_instance_point.x().as_slice());
+        let x_coord = hex::encode(total_instance_point.x());
         // There is no salt because the hash function here is always the same.
-        let w = (Scalar::reduce(U256::from_be_bytes(data.message_hash))
+        let w = (Scalar::reduce(&U256::from_be_bytes(data.message_hash.into()))
             * unique_kept.inversion_mask)
-            + (v * Scalar::reduce(U256::from_be_hex(&x_coord)));
+            + (v * Scalar::reduce(&U256::from_be_hex(&x_coord)));
 
         let broadcast = Broadcast3to4 { u, w };
 
@@ -703,10 +702,10 @@ impl Party {
         // Normalize signature into "low S" form as described in
         // BIP-0062 Dealing with Malleability: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
         if normalize && s.is_high().into() {
-            s = ScalarPrimitive::from(-s).into();
+            s = -s;
         }
 
-        let signature = hex::encode(s.to_bytes().as_slice());
+        let signature = hex::encode(s.to_bytes());
 
         let verification =
             verify_ecdsa_signature(&data.message_hash, &self.pk, x_coord, &signature);
@@ -721,8 +720,8 @@ impl Party {
         // This is necessary because we need to check if y is even or odd to calculate the
         // recovery id. We compute R in the same way that we did in verify_ecdsa_signature:
         // R = (G * msg_hash + pk * r_x) / s
-        let rx_as_scalar = Scalar::reduce(U256::from_be_hex(x_coord));
-        let hashed_msg_as_scalar = Scalar::reduce(U256::from_be_bytes(data.message_hash));
+        let rx_as_scalar = Scalar::reduce(&U256::from_be_hex(x_coord));
+        let hashed_msg_as_scalar = Scalar::reduce(&U256::from_be_bytes(data.message_hash.into()));
         let first = AffinePoint::GENERATOR * hashed_msg_as_scalar;
         let second = self.pk * rx_as_scalar;
         let s_inverse = s.invert().unwrap();
@@ -735,11 +734,11 @@ impl Party {
         // - If R.y is odd  and R.x >= n:               recovery_id = 3
         //
         // is_x_reduced is true when R.x (as a field element) >= the curve order n,
-        // meaning Scalar::reduce(R.x) lost information. For secp256k1, n < p, so
+        // meaning Scalar::reduce(&R.x) lost information. For secp256k1, n < p, so
         // this can happen in the range [n, p-1] with negligible probability.
         let x_as_int = U256::from_be_hex(x_coord);
         let is_x_reduced = x_as_int >= Secp256k1::ORDER;
-        let is_y_odd = signature_point.to_encoded_point(false).y().unwrap()[31] & 1 == 1;
+        let is_y_odd = signature_point.to_sec1_point(false).y().unwrap()[31] & 1 == 1;
         let rec_id = RecoveryId::new(is_y_odd, is_x_reduced);
 
         Ok((signature, rec_id.into()))
@@ -768,12 +767,12 @@ pub fn verify_ecdsa_signature(
         return false;
     }
 
-    let rx_as_scalar = Scalar::reduce(rx_as_int);
-    let s_as_scalar = Scalar::reduce(s_as_int);
+    let rx_as_scalar = Scalar::reduce(&rx_as_int);
+    let s_as_scalar = Scalar::reduce(&s_as_int);
 
     let inverse_s = s_as_scalar.invert().unwrap();
 
-    let first = Scalar::reduce(U256::from_be_bytes(*msg)) * inverse_s;
+    let first = Scalar::reduce(&U256::from_be_bytes((*msg).into())) * inverse_s;
     let second = rx_as_scalar * inverse_s;
 
     let point_to_check = ((AffinePoint::GENERATOR * first) + (*pk * second)).to_affine();
@@ -781,7 +780,7 @@ pub fn verify_ecdsa_signature(
         return false;
     }
 
-    let x_check = Scalar::reduce(U256::from_be_slice(point_to_check.x().as_slice()));
+    let x_check = Scalar::reduce(&U256::from_be_slice(point_to_check.x().as_ref()));
 
     x_check == rx_as_scalar
 }
@@ -793,7 +792,7 @@ mod tests {
     use crate::protocols::re_key::re_key;
     use crate::protocols::*;
     use crate::utilities::hashes::hash;
-    use rand::Rng;
+    use rand::RngExt;
 
     /// Tests if the signing protocol generates a valid ECDSA signature.
     ///
@@ -805,8 +804,8 @@ mod tests {
         // parties are being simulated one after the other, but they
         // should actually execute the protocol simultaneously.
 
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
@@ -814,13 +813,13 @@ mod tests {
         }; // You can fix the parameters if you prefer.
 
         // We use the re_key function to quickly sample the parties.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         // SIGNING
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.
@@ -961,8 +960,8 @@ mod tests {
     /// In this case, parties are sampled via the [`re_key`] function.
     #[test]
     fn test_signing_against_ecdsa() {
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
@@ -970,13 +969,13 @@ mod tests {
         }; // You can fix the parameters if you prefer.
 
         // We use the re_key function to quickly sample the parties.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         // SIGNING (as in test_signing)
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.
@@ -1122,14 +1121,14 @@ mod tests {
 
         // We compare the total "instance point" with the parties' calculations.
         let total_instance_point = (AffinePoint::GENERATOR * total_instance_key).to_affine();
-        let expected_x_coord = hex::encode(total_instance_point.x().as_slice());
+        let expected_x_coord = hex::encode(total_instance_point.x());
         assert_eq!(x_coord, expected_x_coord);
 
         // The hash of the message:
-        let hashed_message = Scalar::reduce(U256::from_be_bytes(message_to_sign));
+        let hashed_message = Scalar::reduce(&U256::from_be_bytes(message_to_sign.into()));
         assert_eq!(
             hashed_message,
-            Scalar::reduce(U256::from_be_hex(
+            Scalar::reduce(&U256::from_be_hex(
                 "ece3e5d77980859352a5e702cb429f3d4dbdc12443e359ae60d15fe3c0333c0d"
             ))
         );
@@ -1137,13 +1136,13 @@ mod tests {
         // Now we can find the signature in the usual way.
         let expected_signature_as_scalar = total_instance_key.invert().unwrap()
             * (hashed_message
-                + (secret_key * Scalar::reduce(U256::from_be_hex(&expected_x_coord))));
-        let expected_signature = hex::encode(expected_signature_as_scalar.to_bytes().as_slice());
+                + (secret_key * Scalar::reduce(&U256::from_be_hex(&expected_x_coord))));
+        let expected_signature = hex::encode(expected_signature_as_scalar.to_bytes());
 
         // Calculate the expected recovery id
         let x_as_int = U256::from_be_hex(&expected_x_coord);
         let is_x_reduced = x_as_int >= Secp256k1::ORDER;
-        let is_y_odd = total_instance_point.to_encoded_point(false).y().unwrap()[31] & 1 == 1;
+        let is_y_odd = total_instance_point.to_sec1_point(false).y().unwrap()[31] & 1 == 1;
         let expected_rec_id = RecoveryId::new(is_y_odd, is_x_reduced);
 
         // We compare the results.
@@ -1159,14 +1158,14 @@ mod tests {
     fn test_dkg_and_signing() {
         // DKG (as in test_dkg_initialization)
 
-        let threshold = rng::get_rng().gen_range(2..=5); // You can change the ranges here.
-        let offset = rng::get_rng().gen_range(0..=5);
+        let threshold = rng::get_rng().random_range(2..=5); // You can change the ranges here.
+        let offset = rng::get_rng().random_range(0..=5);
 
         let parameters = Parameters {
             threshold,
             share_count: threshold + offset,
         }; // You can fix the parameters if you prefer.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Each party prepares their data for this DKG.
         let mut all_data: Vec<SessionData> = Vec::with_capacity(parameters.share_count as usize);
@@ -1340,7 +1339,7 @@ mod tests {
 
         // SIGNING (as in test_signing)
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         // For simplicity, we are testing only the first parties.
@@ -1481,12 +1480,12 @@ mod tests {
             threshold: 2,
             share_count: 2,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
         let data = SignData {
-            sign_id: rng::get_rng().gen::<[u8; 32]>().to_vec(),
+            sign_id: rng::get_rng().random::<[u8; 32]>().to_vec(),
             counterparties: vec![2],
             message_hash: hash("Message to sign!".as_bytes(), &[]),
         };
@@ -1514,11 +1513,11 @@ mod tests {
             threshold: 2,
             share_count: 2,
         };
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let secret_key = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
         let parties = re_key(&parameters, &session_id, &secret_key, None);
 
-        let sign_id = rng::get_rng().gen::<[u8; 32]>();
+        let sign_id = rng::get_rng().random::<[u8; 32]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
 
         let mut all_data: BTreeMap<u8, SignData> = BTreeMap::new();

--- a/src/utilities/commits.rs
+++ b/src/utilities/commits.rs
@@ -7,7 +7,7 @@
 use crate::utilities::hashes::{hash, point_to_bytes, HashOutput};
 use crate::utilities::rng;
 use k256::AffinePoint;
-use rand::Rng;
+use rand::RngExt;
 
 // Computational security parameter lambda_c from DKLs23 (divided by 8)
 use crate::SECURITY;
@@ -65,7 +65,7 @@ mod tests {
     /// Tests if committing and de-committing work.
     #[test]
     fn test_commit_decommit() {
-        let msg = rng::get_rng().gen::<[u8; 32]>();
+        let msg = rng::get_rng().random::<[u8; 32]>();
         let (commitment, salt) = commit(&msg);
         assert!(verify_commitment(&msg, &commitment, &salt));
     }
@@ -74,9 +74,9 @@ mod tests {
     /// to check that if [`verify_commitment`] returns `false`.
     #[test]
     fn test_commit_decommit_fail_msg() {
-        let msg = rng::get_rng().gen::<[u8; 32]>();
+        let msg = rng::get_rng().random::<[u8; 32]>();
         let (commitment, salt) = commit(&msg);
-        let msg = rng::get_rng().gen::<[u8; 32]>(); //We change the message
+        let msg = rng::get_rng().random::<[u8; 32]>(); //We change the message
         assert!(!(verify_commitment(&msg, &commitment, &salt))); //The test can fail but with very low probability
     }
 
@@ -84,9 +84,9 @@ mod tests {
     /// to check that if [`verify_commitment`] returns `false`.
     #[test]
     fn test_commit_decommit_fail_commitment() {
-        let msg = rng::get_rng().gen::<[u8; 32]>();
+        let msg = rng::get_rng().random::<[u8; 32]>();
         let (_, salt) = commit(&msg);
-        let commitment = rng::get_rng().gen::<HashOutput>(); //We change the commitment
+        let commitment = rng::get_rng().random::<HashOutput>(); //We change the commitment
         assert!(!(verify_commitment(&msg, &commitment, &salt))); //The test can fail but with very low probability
     }
 
@@ -94,7 +94,7 @@ mod tests {
     /// to check that if [`verify_commitment`] returns `false`.
     #[test]
     fn test_commit_decommit_fail_salt() {
-        let msg = rng::get_rng().gen::<[u8; 32]>();
+        let msg = rng::get_rng().random::<[u8; 32]>();
         let (commitment, _) = commit(&msg);
         let mut salt = [0u8; 2 * SECURITY as usize];
         rng::get_rng().fill(&mut salt[..]);

--- a/src/utilities/hashes.rs
+++ b/src/utilities/hashes.rs
@@ -35,7 +35,7 @@ pub fn hash(msg: &[u8], salt: &[u8]) -> HashOutput {
 #[must_use]
 pub fn hash_as_int(msg: &[u8], salt: &[u8]) -> U256 {
     let as_bytes = hash(msg, salt);
-    U256::from_be_bytes(as_bytes)
+    U256::from_be_bytes(as_bytes.into())
 }
 
 /// Hash with result as a scalar.
@@ -44,7 +44,7 @@ pub fn hash_as_int(msg: &[u8], salt: &[u8]) -> U256 {
 #[must_use]
 pub fn hash_as_scalar(msg: &[u8], salt: &[u8]) -> Scalar {
     let as_int = hash_as_int(msg, salt);
-    Scalar::reduce(as_int)
+    Scalar::reduce(&as_int)
 }
 
 /// Converts a `Scalar` to bytes.
@@ -53,7 +53,7 @@ pub fn hash_as_scalar(msg: &[u8], salt: &[u8]) -> Scalar {
 /// This function writes this integer as a byte array.
 #[must_use]
 pub fn scalar_to_bytes(scalar: &Scalar) -> Vec<u8> {
-    scalar.to_bytes().as_slice().to_vec()
+    scalar.to_bytes().to_vec()
 }
 
 /// Converts a point on the elliptic curve secp256k1 to bytes.
@@ -62,7 +62,7 @@ pub fn scalar_to_bytes(scalar: &Scalar) -> Vec<u8> {
 /// representation of `point`.
 #[must_use]
 pub fn point_to_bytes(point: &AffinePoint) -> Vec<u8> {
-    point.to_bytes().as_slice().to_vec()
+    point.to_bytes().to_vec()
 }
 
 #[cfg(test)]
@@ -72,7 +72,7 @@ mod tests {
     use crate::utilities::rng;
     use hex;
     use k256::elliptic_curve::{point::AffineCoordinates, Field};
-    use rand::Rng;
+    use rand::RngExt;
 
     /// Tests if [`hash`] really works as `SHA-256` is intended.
     ///
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn test_scalar_to_bytes() {
         for _ in 0..100 {
-            let number: u32 = rng::get_rng().gen();
+            let number: u32 = rng::get_rng().random();
             let scalar = Scalar::from(number);
 
             let number_as_bytes = [vec![0u8; 28], number.to_be_bytes().to_vec()].concat();
@@ -130,14 +130,14 @@ mod tests {
     #[test]
     fn test_point_to_bytes() {
         for _ in 0..100 {
-            let point = (AffinePoint::GENERATOR * Scalar::random(rng::get_rng())).to_affine();
+            let point = (AffinePoint::GENERATOR * Scalar::random(&mut rng::get_rng())).to_affine();
             if point == AffinePoint::IDENTITY {
                 continue;
             }
 
             let mut compressed_point = Vec::with_capacity(33);
             compressed_point.push(if bool::from(point.y_is_odd()) { 3 } else { 2 });
-            compressed_point.extend_from_slice(point.x().as_slice());
+            compressed_point.extend_from_slice(point.x().as_ref());
 
             assert_eq!(compressed_point, point_to_bytes(&point));
         }

--- a/src/utilities/multiplication.rs
+++ b/src/utilities/multiplication.rs
@@ -22,7 +22,7 @@ use crate::utilities::ot::extension::{
     OTEDataToSender, OTEReceiver, OTESender, PRGOutput, BATCH_SIZE,
 };
 use crate::utilities::ot::ErrorOT;
-use rand::Rng;
+use rand::RngExt;
 
 /// Constant `L` from Functionality 3.5 in `DKLs23` used for signing in Protocol 3.6.
 pub const L: u8 = 2;
@@ -171,8 +171,8 @@ impl MulSender {
         let mut a_tilde: Vec<Scalar> = Vec::with_capacity(L as usize);
         let mut a_hat: Vec<Scalar> = Vec::with_capacity(L as usize);
         for _ in 0..L {
-            a_tilde.push(Scalar::random(rng::get_rng()));
-            a_hat.push(Scalar::random(rng::get_rng()));
+            a_tilde.push(Scalar::random(&mut rng::get_rng()));
+            a_hat.push(Scalar::random(&mut rng::get_rng()));
         }
 
         // For the correlation, let us first explain the case L = 1.
@@ -347,7 +347,7 @@ impl MulReceiver {
         // For the choice of the public gadget vector, we will use the same approach
         // as in https://gitlab.com/neucrypt/mpecdsa/-/blob/release/src/mul.rs.
         // We sample a nonce that will be used by both parties to compute a common vector.
-        let nonce = Scalar::random(rng::get_rng());
+        let nonce = Scalar::random(&mut rng::get_rng());
 
         (ot_sender, proof, nonce)
     }
@@ -417,7 +417,7 @@ impl MulReceiver {
         let mut choice_bits: Vec<bool> = Vec::with_capacity(BATCH_SIZE as usize);
         let mut b = Scalar::ZERO;
         for i in 0..BATCH_SIZE {
-            let current_bit: bool = rng::get_rng().gen();
+            let current_bit: bool = rng::get_rng().random();
             if current_bit {
                 b += &self.public_gadget[i as usize];
             }
@@ -591,7 +591,7 @@ impl MulReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::Rng;
+    use rand::RngExt;
 
     fn prepare_mul_receiver_inputs(
         session_id: &[u8; 32],
@@ -625,7 +625,7 @@ mod tests {
         // PROTOCOL
         let mut sender_input: Vec<Scalar> = Vec::with_capacity(L as usize);
         for _ in 0..L {
-            sender_input.push(Scalar::random(rng::get_rng()));
+            sender_input.push(Scalar::random(&mut rng::get_rng()));
         }
 
         let (_, data_to_keep, data_to_sender) = mul_receiver.run_phase1(session_id);
@@ -644,7 +644,7 @@ mod tests {
     /// satisfy the relations they are supposed to satisfy.
     #[test]
     fn test_multiplication() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // INITIALIZATION
 
@@ -690,7 +690,7 @@ mod tests {
         // Sampling the choices.
         let mut sender_input: Vec<Scalar> = Vec::with_capacity(L as usize);
         for _ in 0..L {
-            sender_input.push(Scalar::random(rng::get_rng()));
+            sender_input.push(Scalar::random(&mut rng::get_rng()));
         }
 
         // Phase 1 - Receiver
@@ -741,7 +741,7 @@ mod tests {
     /// Tests if receiver-side multiplication rejects malformed vector lengths.
     #[test]
     fn test_multiplication_receiver_rejects_wrong_verify_vector_lengths() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // INITIALIZATION
         let (ot_sender, dlog_proof, nonce) = MulReceiver::init_phase1(&session_id);
@@ -764,7 +764,7 @@ mod tests {
         // PROTOCOL
         let mut sender_input: Vec<Scalar> = Vec::with_capacity(L as usize);
         for _ in 0..L {
-            sender_input.push(Scalar::random(rng::get_rng()));
+            sender_input.push(Scalar::random(&mut rng::get_rng()));
         }
 
         let (_, data_to_keep, data_to_sender) = mul_receiver.run_phase1(&session_id);
@@ -785,7 +785,7 @@ mod tests {
     /// Tests if the receiver rejects a tampered verify_r hash.
     #[test]
     fn test_multiplication_rejects_tampered_verify_r() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (mul_receiver, data_to_keep, mut data_to_receiver) =
             prepare_mul_receiver_inputs(&session_id);
 
@@ -799,7 +799,7 @@ mod tests {
     /// Tests if the receiver rejects tampered verify_u entries.
     #[test]
     fn test_multiplication_rejects_tampered_verify_u() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (mul_receiver, data_to_keep, mut data_to_receiver) =
             prepare_mul_receiver_inputs(&session_id);
 
@@ -816,7 +816,7 @@ mod tests {
     /// patterns can propagate as incorrect outputs instead of immediate rejection.
     #[test]
     fn test_multiplication_rejects_tampered_tau_vectors() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (mul_receiver, data_to_keep, mut data_to_receiver) =
             prepare_mul_receiver_inputs(&session_id);
 

--- a/src/utilities/ot/base.rs
+++ b/src/utilities/ot/base.rs
@@ -18,7 +18,7 @@
 
 use k256::elliptic_curve::Field;
 use k256::{AffinePoint, ProjectivePoint, Scalar};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
 use crate::utilities::hashes::{hash, hash_as_scalar, point_to_bytes, HashOutput};
@@ -58,7 +58,7 @@ impl OTSender {
         // We sample a nonzero random scalar.
         let mut s = Scalar::ZERO;
         while s == Scalar::ZERO {
-            s = Scalar::random(rng::get_rng());
+            s = Scalar::random(&mut rng::get_rng());
         }
 
         // In the paper, different protocols use different random oracles.
@@ -174,7 +174,7 @@ impl OTReceiver {
     /// Initializes the protocol.
     #[must_use]
     pub fn init() -> OTReceiver {
-        let seed = rng::get_rng().gen::<Seed>();
+        let seed = rng::get_rng().random::<Seed>();
 
         OTReceiver { seed }
     }
@@ -186,7 +186,7 @@ impl OTReceiver {
     #[must_use]
     pub fn run_phase1(&self, session_id: &[u8], bit: bool) -> (Scalar, EncProof) {
         // We sample the secret scalar r.
-        let r = Scalar::random(rng::get_rng());
+        let r = Scalar::random(&mut rng::get_rng());
 
         // We compute h as in the paper.
         // Instead of using a real identifier for the receiver,
@@ -325,7 +325,7 @@ mod tests {
     /// Ensures receiver rejects a tampered DLogProof from sender.
     #[test]
     fn test_ot_base_rejects_tampered_dlog_proof() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         let sender = OTSender::init(&session_id);
         let receiver = OTReceiver::init();
@@ -343,12 +343,12 @@ mod tests {
     /// Ensures sender rejects a tampered encryption proof from receiver.
     #[test]
     fn test_ot_base_rejects_tampered_enc_proof() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         let sender = OTSender::init(&session_id);
         let receiver = OTReceiver::init();
 
-        let bit = rng::get_rng().gen();
+        let bit = rng::get_rng().random();
         let (_, mut enc_proof) = receiver.run_phase1(&session_id, bit);
         let seed = receiver.seed;
 
@@ -365,7 +365,7 @@ mod tests {
     /// satisfy the relations they are supposed to satisfy.
     #[test]
     fn test_ot_base() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Initialization
         let sender = OTSender::init(&session_id);
@@ -375,7 +375,7 @@ mod tests {
         let dlog_proof = sender.run_phase1();
 
         // Phase 1 - Receiver
-        let bit = rng::get_rng().gen();
+        let bit = rng::get_rng().random();
         let (r, enc_proof) = receiver.run_phase1(&session_id, bit);
 
         // Communication round - The parties exchange the proofs.
@@ -413,7 +413,7 @@ mod tests {
     /// Batch version for [`test_ot_base`].
     #[test]
     fn test_ot_base_batch() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // Initialization (unique)
         let sender = OTSender::init(&session_id);
@@ -427,7 +427,7 @@ mod tests {
         // Phase 1 - Receiver
         let mut bits: Vec<bool> = Vec::with_capacity(batch_size);
         for _ in 0..batch_size {
-            bits.push(rng::get_rng().gen());
+            bits.push(rng::get_rng().random());
         }
 
         let (vec_r, enc_proofs) = receiver.run_phase1_batch(&session_id, &bits);

--- a/src/utilities/ot/extension.rs
+++ b/src/utilities/ot/extension.rs
@@ -37,7 +37,7 @@
 //! k vectors of single correlations, where k is the OT width.
 
 use k256::Scalar;
-use rand::Rng;
+use rand::RngExt;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -147,7 +147,7 @@ impl OTESender {
         // The choice bits are sampled randomly.
         let mut correlation: Vec<bool> = Vec::with_capacity(KAPPA as usize);
         for _ in 0..KAPPA {
-            correlation.push(rng::get_rng().gen());
+            correlation.push(rng::get_rng().random());
         }
 
         let (vec_r, enc_proofs) = ot_receiver.run_phase1_batch(session_id, &correlation);
@@ -493,7 +493,7 @@ impl OTEReceiver {
         // Step 1 - Extend the choice bits by adding random noise.
         let mut random_choice_bits: Vec<bool> = Vec::with_capacity(OT_SECURITY as usize);
         for _ in 0..OT_SECURITY {
-            random_choice_bits.push(rng::get_rng().gen());
+            random_choice_bits.push(rng::get_rng().random());
         }
         let extended_choice_bits = [choice_bits, &random_choice_bits].concat();
 
@@ -897,7 +897,7 @@ mod tests {
     use super::*;
     use crate::utilities::hashes::scalar_to_bytes;
     use k256::elliptic_curve::Field;
-    use rand::Rng;
+    use rand::RngExt;
     use std::collections::HashSet;
 
     fn prepare_ote_sender_inputs(
@@ -935,14 +935,14 @@ mod tests {
             let mut current_input_correlation: Vec<Scalar> =
                 Vec::with_capacity(BATCH_SIZE as usize);
             for _ in 0..BATCH_SIZE {
-                current_input_correlation.push(Scalar::random(rng::get_rng()));
+                current_input_correlation.push(Scalar::random(&mut rng::get_rng()));
             }
             sender_input_correlations.push(current_input_correlation);
         }
 
         let mut receiver_choice_bits: Vec<bool> = Vec::with_capacity(BATCH_SIZE as usize);
         for _ in 0..BATCH_SIZE {
-            receiver_choice_bits.push(rng::get_rng().gen());
+            receiver_choice_bits.push(rng::get_rng().random());
         }
         let (_, data_to_sender) = ote_receiver.run_phase1(session_id, &receiver_choice_bits);
 
@@ -957,7 +957,7 @@ mod tests {
     #[test]
     fn test_field_mul() {
         for _ in 0..100 {
-            let initial = rng::get_rng().gen::<FieldElement>();
+            let initial = rng::get_rng().random::<FieldElement>();
 
             //Raising an element to the power 2^208 must not change it.
             let mut result = initial;
@@ -973,7 +973,7 @@ mod tests {
     /// satisfy the relations they are supposed to satisfy.
     #[test]
     fn test_ot_extension() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // INITIALIZATION
 
@@ -1015,14 +1015,14 @@ mod tests {
             let mut current_input_correlation: Vec<Scalar> =
                 Vec::with_capacity(BATCH_SIZE as usize);
             for _ in 0..BATCH_SIZE {
-                current_input_correlation.push(Scalar::random(rng::get_rng()));
+                current_input_correlation.push(Scalar::random(&mut rng::get_rng()));
             }
             sender_input_correlations.push(current_input_correlation);
         }
 
         let mut receiver_choice_bits: Vec<bool> = Vec::with_capacity(BATCH_SIZE as usize);
         for _ in 0..BATCH_SIZE {
-            receiver_choice_bits.push(rng::get_rng().gen());
+            receiver_choice_bits.push(rng::get_rng().random());
         }
 
         // Phase 1 - Receiver
@@ -1138,7 +1138,7 @@ mod tests {
     /// Tests if sender-side OTE rejects malformed dimensions from deserialized input.
     #[test]
     fn test_ot_extension_sender_rejects_malformed_data_dimensions() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // INITIALIZATION
         let (ot_sender, dlog_proof) = OTEReceiver::init_phase1(&session_id);
@@ -1156,13 +1156,13 @@ mod tests {
         let mut sender_input_correlations: Vec<Vec<Scalar>> = Vec::with_capacity(1);
         let mut correlation_row: Vec<Scalar> = Vec::with_capacity(BATCH_SIZE as usize);
         for _ in 0..BATCH_SIZE {
-            correlation_row.push(Scalar::random(rng::get_rng()));
+            correlation_row.push(Scalar::random(&mut rng::get_rng()));
         }
         sender_input_correlations.push(correlation_row);
 
         let mut receiver_choice_bits: Vec<bool> = Vec::with_capacity(BATCH_SIZE as usize);
         for _ in 0..BATCH_SIZE {
-            receiver_choice_bits.push(rng::get_rng().gen());
+            receiver_choice_bits.push(rng::get_rng().random());
         }
         let (_, data_to_sender) = ote_receiver.run_phase1(&session_id, &receiver_choice_bits);
 
@@ -1182,7 +1182,7 @@ mod tests {
     /// Tests if receiver-side OTE rejects tau vectors with incorrect inner length.
     #[test]
     fn test_ot_extension_receiver_rejects_short_tau_rows() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         // INITIALIZATION
         let (ot_sender, _) = OTEReceiver::init_phase1(&session_id);
@@ -1195,7 +1195,7 @@ mod tests {
         // Phase 1 - Receiver
         let mut receiver_choice_bits: Vec<bool> = Vec::with_capacity(BATCH_SIZE as usize);
         for _ in 0..BATCH_SIZE {
-            receiver_choice_bits.push(rng::get_rng().gen());
+            receiver_choice_bits.push(rng::get_rng().random());
         }
         let (extended_seeds, _) = ote_receiver.run_phase1(&session_id, &receiver_choice_bits);
 
@@ -1215,7 +1215,7 @@ mod tests {
     /// Tests if sender-side OTE rejects tampered u matrix rows.
     #[test]
     fn test_ot_extension_sender_rejects_tampered_u() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let ot_width = 2;
         let (ote_sender, sender_input_correlations, mut data_to_sender) =
             prepare_ote_sender_inputs(&session_id, ot_width);
@@ -1235,7 +1235,7 @@ mod tests {
     /// Tests if sender-side OTE rejects tampered verify_x.
     #[test]
     fn test_ot_extension_sender_rejects_tampered_verify_x() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let ot_width = 2;
         let (ote_sender, sender_input_correlations, mut data_to_sender) =
             prepare_ote_sender_inputs(&session_id, ot_width);
@@ -1255,7 +1255,7 @@ mod tests {
     /// Tests if sender-side OTE rejects tampered verify_t entries.
     #[test]
     fn test_ot_extension_sender_rejects_tampered_verify_t() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         // Exercise a different width than the other adversarial OTE tests.
         let ot_width = 1;
         let (ote_sender, sender_input_correlations, mut data_to_sender) =

--- a/src/utilities/proofs.rs
+++ b/src/utilities/proofs.rs
@@ -35,7 +35,7 @@
 
 use k256::elliptic_curve::{ops::Reduce, Field};
 use k256::{AffinePoint, ProjectivePoint, Scalar, U256};
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -61,7 +61,7 @@ impl InteractiveDLogProof {
     ///
     /// The `Scalar` is kept secret while the `AffinePoint` is transmitted.
     #[must_use]
-    pub fn prove_step1(mut rng: impl RngCore) -> (Scalar, AffinePoint) {
+    pub fn prove_step1(mut rng: impl Rng) -> (Scalar, AffinePoint) {
         // We sample a nonzero random scalar.
         let mut scalar_rand_commitment = Scalar::ZERO;
         while scalar_rand_commitment == Scalar::ZERO {
@@ -89,7 +89,7 @@ impl InteractiveDLogProof {
         let mut extended = vec![0u8; (32 - T / 8) as usize];
         extended.extend_from_slice(challenge);
 
-        let challenge_scalar = Scalar::reduce(U256::from_be_slice(&extended));
+        let challenge_scalar = Scalar::reduce(&U256::from_be_slice(&extended));
 
         // We compute the response.
         let challenge_response = scalar_rand_commitment - &(challenge_scalar * scalar);
@@ -123,7 +123,7 @@ impl InteractiveDLogProof {
         let mut extended = vec![0u8; (32 - T / 8) as usize];
         extended.extend_from_slice(&self.challenge);
 
-        let challenge_scalar = Scalar::reduce(U256::from_be_slice(&extended));
+        let challenge_scalar = Scalar::reduce(&U256::from_be_slice(&extended));
 
         // We compare the values that should agree.
         let point_verify = ((AffinePoint::GENERATOR * self.challenge_response)
@@ -197,7 +197,7 @@ impl DLogProof {
             let mut first_counter = 0u16;
             while first_counter < u16::MAX && !flag {
                 // We sample an array of T bits = T/8 bytes.
-                let first_challenge = rng::get_rng().gen::<[u8; (T / 8) as usize]>();
+                let first_challenge = rng::get_rng().random::<[u8; (T / 8) as usize]>();
 
                 // If this challenge was already sampled, we should go back.
                 // However, with some tests, we saw that it is time consuming
@@ -235,7 +235,7 @@ impl DLogProof {
                 let mut rng = rng::get_rng();
                 while second_counter < u16::MAX {
                     // We sample another array. Same considerations as before.
-                    let second_challenge = rng.gen::<[u8; (T / 8) as usize]>();
+                    let second_challenge = rng.random::<[u8; (T / 8) as usize]>();
 
                     //if used_second_challenges.contains(&second_challenge) { continue; }
 
@@ -488,7 +488,7 @@ impl CPProof {
         // We sample a nonzero random scalar.
         let mut scalar_rand_commitment = Scalar::ZERO;
         while scalar_rand_commitment == Scalar::ZERO {
-            scalar_rand_commitment = Scalar::random(rng::get_rng());
+            scalar_rand_commitment = Scalar::random(&mut rng::get_rng());
         }
 
         let point_rand_commitment_g = (*base_g * scalar_rand_commitment).to_affine();
@@ -562,9 +562,9 @@ impl CPProof {
         point_v: &AffinePoint,
     ) -> (RandomCommitments, Scalar, CPProof) {
         // We sample the challenge and the response first.
-        let challenge = Scalar::random(rng::get_rng());
+        let challenge = Scalar::random(&mut rng::get_rng());
 
-        let challenge_response = Scalar::random(rng::get_rng());
+        let challenge_response = Scalar::random(&mut rng::get_rng());
 
         // Now we compute the "random" commitments that work for this challenge.
         let point_rand_commitment_g =
@@ -831,8 +831,8 @@ mod tests {
     /// Tests if proving and verifying work for [`DLogProof`].
     #[test]
     fn test_dlog_proof() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let proof = DLogProof::prove(&scalar, &session_id);
         assert!(DLogProof::verify(&proof, &session_id));
     }
@@ -841,8 +841,8 @@ mod tests {
     /// to see if the verify function detects.
     #[test]
     fn test_dlog_proof_fail_proof() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let mut proof = DLogProof::prove(&scalar, &session_id);
         proof.proofs[0].challenge_response *= Scalar::from(2u32); //Changing the proof
         assert!(!(DLogProof::verify(&proof, &session_id)));
@@ -851,8 +851,8 @@ mod tests {
     /// Ensures duplicated random commitments are rejected.
     #[test]
     fn test_dlog_proof_rejects_duplicate_rand_commitments() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let mut proof = DLogProof::prove(&scalar, &session_id);
         proof.rand_commitments[1] = proof.rand_commitments[0];
         assert!(!DLogProof::verify(&proof, &session_id));
@@ -861,8 +861,8 @@ mod tests {
     /// Ensures wrong proof/commitment vector lengths are rejected.
     #[test]
     fn test_dlog_proof_rejects_wrong_vector_lengths() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
         let mut proof_short_commitments = DLogProof::prove(&scalar, &session_id);
         proof_short_commitments.rand_commitments.pop();
@@ -876,8 +876,8 @@ mod tests {
     /// Ensures session-id mismatches invalidate the proof.
     #[test]
     fn test_dlog_proof_rejects_mismatched_session_id() {
-        let scalar = Scalar::random(rng::get_rng());
-        let prove_sid = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let prove_sid = rng::get_rng().random::<[u8; 32]>();
         let mut verify_sid = prove_sid;
         verify_sid[0] ^= 1;
         let proof = DLogProof::prove(&scalar, &prove_sid);
@@ -888,8 +888,8 @@ mod tests {
     /// in the case with commitment.
     #[test]
     fn test_dlog_proof_commit() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (proof, commitment) = DLogProof::prove_commit(&scalar, &session_id);
         assert!(DLogProof::decommit_verify(&proof, &commitment, &session_id));
     }
@@ -898,8 +898,8 @@ mod tests {
     /// the proof on purpose to see if the verify function detects.
     #[test]
     fn test_dlog_proof_commit_fail_proof() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (mut proof, commitment) = DLogProof::prove_commit(&scalar, &session_id);
         proof.proofs[0].challenge_response *= Scalar::from(2u32); //Changing the proof
         assert!(!(DLogProof::decommit_verify(&proof, &commitment, &session_id)));
@@ -909,8 +909,8 @@ mod tests {
     /// the commitment on purpose to see if the verify function detects.
     #[test]
     fn test_dlog_proof_commit_fail_commitment() {
-        let scalar = Scalar::random(rng::get_rng());
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let (proof, mut commitment) = DLogProof::prove_commit(&scalar, &session_id);
         if commitment[0] == 0 {
             commitment[0] = 1;
@@ -925,9 +925,9 @@ mod tests {
     /// Tests if proving and verifying work for [`CPProof`].
     #[test]
     fn test_cp_proof() {
-        let log_base_g = Scalar::random(rng::get_rng());
-        let log_base_h = Scalar::random(rng::get_rng());
-        let scalar = Scalar::random(rng::get_rng());
+        let log_base_g = Scalar::random(&mut rng::get_rng());
+        let log_base_h = Scalar::random(&mut rng::get_rng());
+        let scalar = Scalar::random(&mut rng::get_rng());
 
         let generator = AffinePoint::GENERATOR;
         let base_g = (generator * log_base_g).to_affine();
@@ -937,7 +937,7 @@ mod tests {
         let (scalar_rand_commitment, rand_commitments) = CPProof::prove_step1(&base_g, &base_h);
 
         // Verifier - Gather the commitments and choose the challenge.
-        let challenge = Scalar::random(rng::get_rng());
+        let challenge = Scalar::random(&mut rng::get_rng());
 
         // Prover - Step 2.
         let proof = CPProof::prove_step2(
@@ -957,10 +957,10 @@ mod tests {
     /// Tests if simulating a fake proof and verifying work for [`CPProof`].
     #[test]
     fn test_cp_proof_simulate() {
-        let log_base_g = Scalar::random(rng::get_rng());
-        let log_base_h = Scalar::random(rng::get_rng());
-        let log_point_u = Scalar::random(rng::get_rng());
-        let log_point_v = Scalar::random(rng::get_rng());
+        let log_base_g = Scalar::random(&mut rng::get_rng());
+        let log_base_h = Scalar::random(&mut rng::get_rng());
+        let log_point_u = Scalar::random(&mut rng::get_rng());
+        let log_point_v = Scalar::random(&mut rng::get_rng());
 
         let generator = AffinePoint::GENERATOR;
         let base_g = (generator * log_base_g).to_affine();
@@ -980,10 +980,10 @@ mod tests {
     /// Ensures simulated proofs fail when verified against a different statement.
     #[test]
     fn test_cp_proof_simulate_wrong_statement_fails() {
-        let log_base_g = Scalar::random(rng::get_rng());
-        let log_base_h = Scalar::random(rng::get_rng());
-        let log_point_u = Scalar::random(rng::get_rng());
-        let log_point_v = Scalar::random(rng::get_rng());
+        let log_base_g = Scalar::random(&mut rng::get_rng());
+        let log_base_h = Scalar::random(&mut rng::get_rng());
+        let log_point_u = Scalar::random(&mut rng::get_rng());
+        let log_point_v = Scalar::random(&mut rng::get_rng());
 
         let generator = AffinePoint::GENERATOR;
         let base_g = (generator * log_base_g).to_affine();
@@ -1006,14 +1006,14 @@ mod tests {
     #[test]
     fn test_enc_proof() {
         // We sample the initial values.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
 
-        let log_base_h = Scalar::random(rng::get_rng());
+        let log_base_h = Scalar::random(&mut rng::get_rng());
         let base_h = (AffinePoint::GENERATOR * log_base_h).to_affine();
 
-        let scalar = Scalar::random(rng::get_rng());
+        let scalar = Scalar::random(&mut rng::get_rng());
 
-        let bit: bool = rng::get_rng().gen();
+        let bit: bool = rng::get_rng().random();
 
         // Proving.
         let proof = EncProof::prove(&session_id, &base_h, &scalar, bit);
@@ -1027,11 +1027,11 @@ mod tests {
     /// Ensures incompatible sub-proofs are rejected.
     #[test]
     fn test_enc_proof_rejects_incompatible_subproofs() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let log_base_h = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let log_base_h = Scalar::random(&mut rng::get_rng());
         let base_h = (AffinePoint::GENERATOR * log_base_h).to_affine();
-        let scalar = Scalar::random(rng::get_rng());
-        let bit: bool = rng::get_rng().gen();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let bit: bool = rng::get_rng().random();
 
         let mut proof = EncProof::prove(&session_id, &base_h, &scalar, bit);
         proof.proof0.base_g = (AffinePoint::GENERATOR * Scalar::from(2u32)).to_affine();
@@ -1042,11 +1042,11 @@ mod tests {
     /// Ensures challenge-sum mismatch is rejected.
     #[test]
     fn test_enc_proof_rejects_challenge_sum_mismatch() {
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
-        let log_base_h = Scalar::random(rng::get_rng());
+        let session_id = rng::get_rng().random::<[u8; 32]>();
+        let log_base_h = Scalar::random(&mut rng::get_rng());
         let base_h = (AffinePoint::GENERATOR * log_base_h).to_affine();
-        let scalar = Scalar::random(rng::get_rng());
-        let bit: bool = rng::get_rng().gen();
+        let scalar = Scalar::random(&mut rng::get_rng());
+        let bit: bool = rng::get_rng().random();
 
         let mut proof = EncProof::prove(&session_id, &base_h, &scalar, bit);
         proof.challenge0 += Scalar::ONE;

--- a/src/utilities/rng.rs
+++ b/src/utilities/rng.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_SEED: u64 = 42;
 
 #[cfg(not(all(test, feature = "insecure-rng")))]
 pub fn get_rng() -> ThreadRng {
-    rand::thread_rng()
+    rand::rng()
 }
 
 #[cfg(all(test, feature = "insecure-rng"))]

--- a/src/utilities/zero_shares.rs
+++ b/src/utilities/zero_shares.rs
@@ -10,7 +10,7 @@ use crate::utilities::hashes::{hash_as_scalar, HashOutput};
 
 use crate::utilities::rng;
 use k256::Scalar;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -45,7 +45,7 @@ impl ZeroShare {
     /// At the time of de-commitment, these secret values are revealed.
     #[must_use]
     pub fn generate_seed_with_commitment() -> (Seed, HashOutput, Vec<u8>) {
-        let seed = rng::get_rng().gen::<Seed>();
+        let seed = rng::get_rng().random::<Seed>();
         let (commitment, salt) = commits::commit(&seed);
         (seed, commitment, salt)
     }
@@ -176,7 +176,7 @@ mod tests {
         }
 
         //We can finally execute the functionality.
-        let session_id = rng::get_rng().gen::<[u8; 32]>();
+        let session_id = rng::get_rng().random::<[u8; 32]>();
         let executing_parties: Vec<u8> = vec![1, 3, 5, 7, 8]; //These are the parties running the protocol.
         let mut shares: Vec<Scalar> = Vec::with_capacity(executing_parties.len());
         for party in executing_parties.clone() {


### PR DESCRIPTION
## Summary
- upgrade cryptography/randomness dependency families for modernization work in #47
  - k256 -> 0.14.0-rc.7
  - rand -> 0.10
  - getrandom wasm target override -> 0.4 (wasm_js)
- migrate rand API usage throughout the codebase (gen/gen_range -> random/random_range, thread_rng -> rng)
- adapt to new k256 APIs
  - ToEncodedPoint -> ToSec1Point
  - Scalar::random call sites now use &mut RNG
  - Scalar::reduce call sites now pass borrowed inputs
  - U256::from_be_bytes call sites updated to new input expectations
- remove deprecated GenericArray::as_slice usage in signing/hash utilities

## Validation
- cargo test (61 passed, 0 failed)
- cargo clippy (pass; deprecation warnings eliminated)

Closes #47
