### PR TITLE
feat: PublicKeyPackage Type

### DIFF
--- a/src/protocols.rs
+++ b/src/protocols.rs
@@ -8,6 +8,7 @@ use k256::{AffinePoint, Scalar};
 use zeroize::Zeroize;
 
 use crate::protocols::derivation::DerivData;
+pub use crate::protocols::dkg::compute_eth_address;
 use crate::utilities::multiplication::{MulReceiver, MulSender};
 use crate::utilities::zero_shares::ZeroShare;
 
@@ -134,6 +135,63 @@ impl Zeroize for Party {
 impl Drop for Party {
     fn drop(&mut self) {
         self.zeroize();
+    }
+}
+
+/// Aggregates the group public key, per-participant verification shares,
+/// and threshold parameters produced by DKG or re-key.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PublicKeyPackage {
+    verifying_key: AffinePoint,
+    verifying_shares: BTreeMap<PartyIndex, AffinePoint>,
+    parameters: Parameters,
+}
+
+impl PublicKeyPackage {
+    #[must_use]
+    pub fn new(
+        verifying_key: AffinePoint,
+        verifying_shares: BTreeMap<PartyIndex, AffinePoint>,
+        parameters: Parameters,
+    ) -> Self {
+        Self {
+            verifying_key,
+            verifying_shares,
+            parameters,
+        }
+    }
+
+    #[must_use]
+    pub fn verifying_key(&self) -> &AffinePoint {
+        &self.verifying_key
+    }
+
+    #[must_use]
+    pub fn verifying_share(&self, party: PartyIndex) -> Option<&AffinePoint> {
+        self.verifying_shares.get(&party)
+    }
+
+    #[must_use]
+    pub fn threshold(&self) -> u8 {
+        self.parameters.threshold
+    }
+
+    #[must_use]
+    pub fn share_count(&self) -> u8 {
+        self.parameters.share_count
+    }
+
+    #[must_use]
+    pub fn ethereum_address(&self) -> String {
+        compute_eth_address(&self.verifying_key)
+    }
+
+    #[must_use]
+    pub fn verify_share(&self, party: PartyIndex, verification_share: &AffinePoint) -> bool {
+        self.verifying_shares
+            .get(&party)
+            .is_some_and(|stored| stored == verification_share)
     }
 }
 

--- a/src/protocols/derivation.rs
+++ b/src/protocols/derivation.rs
@@ -18,7 +18,7 @@ use k256::elliptic_curve::{ops::Reduce, Curve};
 use k256::{AffinePoint, Scalar, Secp256k1, U256};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::protocols::Party;
+use crate::protocols::{Party, PublicKeyPackage};
 use crate::utilities::hashes::point_to_bytes;
 
 use super::dkg::compute_eth_address;
@@ -264,6 +264,63 @@ impl Party {
     }
 }
 
+/// Implementations related to BIP-32 derivation for [`PublicKeyPackage`].
+impl PublicKeyPackage {
+    /// Derives a child [`PublicKeyPackage`] given a chain code and child number.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the child number is invalid or the HMAC
+    /// result is out of range (very unlikely).
+    pub fn derive_child(
+        &self,
+        chain_code: &ChainCode,
+        child_number: u32,
+    ) -> Result<PublicKeyPackage, ErrorDeriv> {
+        if child_number > MAX_CHILD_NUMBER {
+            return Err(ErrorDeriv::new(
+                "Child index should be between 0 and 2^31 - 1!",
+            ));
+        }
+
+        let mut hmac_engine: HmacEngine<sha512::Hash> = HmacEngine::new(&chain_code[..]);
+        let pk_as_bytes = point_to_bytes(self.verifying_key());
+        hmac_engine.input(&pk_as_bytes);
+        hmac_engine.input(&child_number.to_be_bytes());
+        let hmac_result = Hmac::<sha512::Hash>::from_engine(hmac_engine);
+        let hmac_bytes = hmac_result.to_byte_array();
+
+        let number_for_tweak = U256::from_be_slice(&hmac_bytes[..CHAIN_CODE_LEN]);
+        if number_for_tweak.ge(&Secp256k1::ORDER) {
+            return Err(ErrorDeriv::new(
+                "Very improbable: Child index results in value not allowed by BIP-32!",
+            ));
+        }
+        let tweak = Scalar::reduce(&number_for_tweak);
+
+        let tweak_point = AffinePoint::GENERATOR * tweak;
+        let new_verifying_key = (tweak_point + *self.verifying_key()).to_affine();
+
+        if new_verifying_key == AffinePoint::IDENTITY {
+            return Err(ErrorDeriv::new(
+                "Very improbable: Child index results in value not allowed by BIP-32!",
+            ));
+        }
+
+        let new_verifying_shares = self
+            .verifying_shares
+            .iter()
+            .map(|(party, share)| (*party, (tweak_point + *share).to_affine()))
+            .collect();
+
+        Ok(PublicKeyPackage::new(
+            new_verifying_key,
+            new_verifying_shares,
+            self.parameters.clone(),
+        ))
+    }
+}
+
 /// Takes a path as in BIP-32 (for normal derivation),
 /// and transforms it into a vector of child numbers.
 ///
@@ -386,7 +443,7 @@ mod tests {
         // We use the re_key function to quickly sample the parties.
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         // DERIVATION
 
@@ -550,6 +607,34 @@ mod tests {
         );
         if let Err(abort) = result {
             panic!("Party {} aborted: {:?}", abort.index, abort.description);
+        }
+    }
+
+    /// Tests if [`PublicKeyPackage::derive_child`] produces a package
+    /// consistent with per-party derivation via [`Party::derive_child`].
+    #[test]
+    fn test_public_key_package_derive_child() {
+        let parameters = Parameters {
+            threshold: 2,
+            share_count: 3,
+        };
+        let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
+        let secret_key = Scalar::random(&mut rng::get_rng());
+        let (parties, pkg) = re_key(&parameters, &session_id, &secret_key, None);
+
+        let chain_code = parties[0].derivation_data.chain_code;
+        const TEST_CHILD_NUMBER: u32 = 42;
+        let child_number = TEST_CHILD_NUMBER;
+
+        let derived_pkg = pkg.derive_child(&chain_code, child_number).unwrap();
+
+        // Derive each party individually and verify consistency.
+        for party in &parties {
+            let derived_party = party.derive_child(child_number).unwrap();
+            assert_eq!(*derived_pkg.verifying_key(), derived_party.pk);
+
+            let expected_share = (AffinePoint::GENERATOR * derived_party.poly_point).to_affine();
+            assert!(derived_pkg.verify_share(party.party_index, &expected_share));
         }
     }
 }

--- a/src/protocols/dkg.rs
+++ b/src/protocols/dkg.rs
@@ -57,7 +57,7 @@ use rand::RngExt;
 use sha3::{Digest, Keccak256};
 
 use crate::protocols::derivation::{ChainCode, DerivData, CHAIN_CODE_LEN};
-use crate::protocols::{Abort, Parameters, PartiesMessage, Party, PartyIndex};
+use crate::protocols::{Abort, Parameters, PartiesMessage, Party, PartyIndex, PublicKeyPackage};
 
 use crate::utilities::commits;
 use crate::utilities::hashes::HashOutput;
@@ -324,7 +324,7 @@ pub(crate) fn step5(
     party_index: PartyIndex,
     session_id: &[u8],
     proofs_commitments: &[ProofCommitment],
-) -> Result<AffinePoint, Abort> {
+) -> Result<(AffinePoint, BTreeMap<PartyIndex, AffinePoint>), Abort> {
     let mut committed_points: BTreeMap<PartyIndex, AffinePoint> = BTreeMap::new(); //The "public key fragments"
 
     // Verify the proofs and gather the committed points.
@@ -389,7 +389,7 @@ pub(crate) fn step5(
             ));
         }
     }
-    Ok(pk)
+    Ok((pk, committed_points))
 }
 
 // PHASES
@@ -700,9 +700,9 @@ pub(crate) fn phase4(
     mul_received: &[TransmitInitMulPhase3to4],
     bip_received_phase2: &BTreeMap<PartyIndex, BroadcastDerivationPhase2to4>,
     bip_received_phase3: &BTreeMap<PartyIndex, BroadcastDerivationPhase3to4>,
-) -> Result<Party, Abort> {
+) -> Result<(Party, PublicKeyPackage), Abort> {
     // DKG
-    let pk = step5(
+    let (pk, verifying_shares) = step5(
         &data.parameters,
         data.party_index,
         &data.session_id,
@@ -1047,7 +1047,9 @@ pub(crate) fn phase4(
         eth_address,
     };
 
-    Ok(party)
+    let public_key_package = PublicKeyPackage::new(pk, verifying_shares, data.parameters.clone());
+
+    Ok((party, public_key_package))
 }
 
 /// Computes the Ethereum address given a public key.
@@ -1386,18 +1388,13 @@ mod tests {
         }
 
         // Phase 4 (Step 5)
-        let mut result_parties: Vec<Result<AffinePoint, Abort>> =
-            Vec::with_capacity(parameters.share_count as usize);
         for i in 0..parameters.share_count {
-            result_parties.push(step5(
+            let result = step5(
                 &parameters,
                 PartyIndex::new(i + 1).unwrap(),
                 &session_id,
                 &proofs_commitments,
-            ));
-        }
-
-        for result in result_parties {
+            );
             assert!(result.is_ok());
         }
     }
@@ -1454,8 +1451,8 @@ mod tests {
         assert!(p1_result.is_ok());
         assert!(p2_result.is_ok());
 
-        let p1_pk = p1_result.unwrap();
-        let p2_pk = p2_result.unwrap();
+        let (p1_pk, _) = p1_result.unwrap();
+        let (p2_pk, _) = p2_result.unwrap();
 
         // Verifying the public key
         let expected_pk = (AffinePoint::GENERATOR * Scalar::from(2u32)).to_affine();
@@ -1509,8 +1506,8 @@ mod tests {
         assert!(p1_result.is_ok());
         assert!(p2_result.is_ok());
 
-        let p1_pk = p1_result.unwrap();
-        let p2_pk = p2_result.unwrap();
+        let (p1_pk, _) = p1_result.unwrap();
+        let (p2_pk, _) = p2_result.unwrap();
 
         // Verifying the public key
         let expected_pk = (AffinePoint::GENERATOR * Scalar::from(23u32)).to_affine();
@@ -1588,27 +1585,18 @@ mod tests {
         }
 
         // Phase 4 (Step 5)
-        let mut results: Vec<Result<AffinePoint, Abort>> =
-            Vec::with_capacity(parameters.share_count as usize);
+        let mut public_keys: Vec<AffinePoint> = Vec::with_capacity(parameters.share_count as usize);
         for i in 0..parameters.share_count {
-            results.push(step5(
+            let (pk, _) = step5(
                 &parameters,
                 PartyIndex::new(i + 1).unwrap(),
                 &session_id,
                 &proofs_commitments,
-            ));
-        }
-
-        let mut public_keys: Vec<AffinePoint> = Vec::with_capacity(parameters.share_count as usize);
-        for result in results {
-            match result {
-                Ok(pk) => {
-                    public_keys.push(pk);
-                }
-                Err(abort) => {
-                    panic!("Party {} aborted: {:?}", abort.index, abort.description);
-                }
-            }
+            )
+            .unwrap_or_else(|abort| {
+                panic!("Party {} aborted: {:?}", abort.index, abort.description);
+            });
+            public_keys.push(pk);
         }
 
         // Verifying the public key
@@ -1787,6 +1775,7 @@ mod tests {
 
         // Phase 4
         let mut parties: Vec<Party> = Vec::with_capacity((parameters.share_count) as usize);
+        let mut pkgs: Vec<PublicKeyPackage> = Vec::with_capacity(parameters.share_count as usize);
         for i in 0..parameters.share_count {
             let result = phase4(
                 &all_data[i as usize],
@@ -1804,8 +1793,9 @@ mod tests {
                 Err(abort) => {
                     panic!("Party {} aborted: {:?}", abort.index, abort.description);
                 }
-                Ok(party) => {
+                Ok((party, pkg)) => {
                     parties.push(party);
+                    pkgs.push(pkg);
                 }
             }
         }
@@ -1817,6 +1807,28 @@ mod tests {
             assert_eq!(expected_pk, party.pk);
             assert_eq!(expected_chain_code, party.derivation_data.chain_code);
         }
+
+        // All parties must produce identical PublicKeyPackages.
+        let pkg0 = &pkgs[0];
+        assert_eq!(*pkg0.verifying_key(), expected_pk);
+        assert_eq!(pkg0.threshold(), parameters.threshold);
+        assert_eq!(pkg0.share_count(), parameters.share_count);
+        for pkg in &pkgs[1..] {
+            assert_eq!(pkg.verifying_key(), pkg0.verifying_key());
+            for i in 1..=parameters.share_count {
+                let idx = PartyIndex::new(i).unwrap();
+                assert_eq!(pkg.verifying_share(idx), pkg0.verifying_share(idx));
+            }
+        }
+
+        // Each verification share must equal poly_point * G for the corresponding party.
+        for party in &parties {
+            let expected_share = (AffinePoint::GENERATOR * party.poly_point).to_affine();
+            assert!(pkg0.verify_share(party.party_index, &expected_share));
+        }
+
+        // ethereum_address must match the address from Party.
+        assert_eq!(pkg0.ethereum_address(), parties[0].eth_address);
     }
 
     /// Tests if [`compute_eth_address`] correctly

--- a/src/protocols/dkg_session.rs
+++ b/src/protocols/dkg_session.rs
@@ -10,7 +10,7 @@ use crate::protocols::dkg::{
     TransmitInitMulPhase3to4, TransmitInitZeroSharePhase2to4, TransmitInitZeroSharePhase3to4,
     UniqueKeepDerivationPhase2to3,
 };
-use crate::protocols::{Abort, Parameters, Party, PartyIndex};
+use crate::protocols::{Abort, Parameters, Party, PartyIndex, PublicKeyPackage};
 
 pub struct DkgSession {
     data: SessionData,
@@ -124,7 +124,7 @@ impl DkgSession {
         mul_received: &[TransmitInitMulPhase3to4],
         bip_received_phase2: &BTreeMap<PartyIndex, BroadcastDerivationPhase2to4>,
         bip_received_phase3: &BTreeMap<PartyIndex, BroadcastDerivationPhase3to4>,
-    ) -> Result<Party, Abort> {
+    ) -> Result<(Party, PublicKeyPackage), Abort> {
         let poly_point = self
             .poly_point
             .as_ref()
@@ -347,7 +347,7 @@ mod tests {
         // Phase 4
         let mut parties: Vec<Party> = Vec::with_capacity(n);
         for (i, session) in sessions.into_iter().enumerate() {
-            let party = session
+            let (party, _pkg) = session
                 .phase4(
                     &proofs_commitments,
                     &zero_received_2to4[i],

--- a/src/protocols/messages.rs
+++ b/src/protocols/messages.rs
@@ -86,6 +86,12 @@ fn find_in_stream<T: MessageTag>(stream: &[u8]) -> Result<T, MessageError> {
     Err(MessageError::NotFound { sender: 0 })
 }
 
+impl Default for PhaseOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PhaseOutput {
     #[must_use]
     pub fn new() -> Self {

--- a/src/protocols/re_key.rs
+++ b/src/protocols/re_key.rs
@@ -17,7 +17,7 @@ use rand::RngExt;
 
 use crate::protocols::derivation::{ChainCode, DerivData};
 use crate::protocols::dkg::compute_eth_address;
-use crate::protocols::{Parameters, Party, PartyIndex};
+use crate::protocols::{Parameters, Party, PartyIndex, PublicKeyPackage};
 
 use crate::utilities::hashes::HashOutput;
 use crate::utilities::multiplication::{MulReceiver, MulSender};
@@ -41,7 +41,7 @@ pub fn re_key(
     session_id: &[u8],
     secret_key: &Scalar,
     option_chain_code: Option<ChainCode>,
-) -> Vec<Party> {
+) -> (Vec<Party>, PublicKeyPackage) {
     // Public key.
     let pk = (AffinePoint::GENERATOR * secret_key).to_affine();
 
@@ -220,7 +220,19 @@ pub fn re_key(
         });
     }
 
-    parties
+    let verifying_shares: BTreeMap<PartyIndex, AffinePoint> = parties
+        .iter()
+        .map(|p| {
+            (
+                p.party_index,
+                (AffinePoint::GENERATOR * p.poly_point).to_affine(),
+            )
+        })
+        .collect();
+
+    let public_key_package = PublicKeyPackage::new(pk, verifying_shares, parameters.clone());
+
+    (parties, public_key_package)
 }
 
 // For tests, see the file signing.rs. It uses the function above.

--- a/src/protocols/refresh.rs
+++ b/src/protocols/refresh.rs
@@ -394,7 +394,7 @@ impl Party {
         // Again, the derivation part is omitted.
 
         // DKG
-        let verifying_pk = step5(
+        let (verifying_pk, _) = step5(
             &self.parameters,
             self.party_index,
             refresh_sid,
@@ -838,7 +838,7 @@ impl Party {
         // Again, the derivation part is omitted.
 
         // DKG
-        let verifying_pk = step5(
+        let (verifying_pk, _) = step5(
             &self.parameters,
             self.party_index,
             refresh_sid,
@@ -1165,7 +1165,7 @@ mod tests {
         };
         let session_id = rng::get_rng().random::<[u8; SESSION_ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let refresh_sid = rng::get_rng().random::<[u8; SESSION_ID_LEN]>();
 
@@ -1399,7 +1399,7 @@ mod tests {
         // We use the re_key function to quickly sample the parties.
         let session_id = rng::get_rng().random::<[u8; SESSION_ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         // REFRESH (it follows test_dkg_initialization closely)
 
@@ -1698,7 +1698,7 @@ mod tests {
         // We use the re_key function to quickly sample the parties.
         let session_id = rng::get_rng().random::<[u8; SESSION_ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         // REFRESH (faster version)
 

--- a/src/protocols/sign_session.rs
+++ b/src/protocols/sign_session.rs
@@ -93,7 +93,7 @@ mod tests {
     use crate::protocols::re_key::re_key;
     use crate::protocols::signing::{verify_ecdsa_signature, SignData};
     use crate::protocols::Parameters;
-    use crate::utilities::hashes::hash;
+    use crate::utilities::hashes::tagged_hash;
     use crate::utilities::rng;
     use rand::RngExt;
 
@@ -108,10 +108,10 @@ mod tests {
 
         let session_id = rng::get_rng().random::<[u8; 32]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let sign_id = rng::get_rng().random::<[u8; 32]>();
-        let message_to_sign = hash("Message to sign!".as_bytes(), &[]);
+        let message_to_sign = tagged_hash(b"test-sign", &["Message to sign!".as_bytes()]);
         let executing_parties: Vec<u8> = Vec::from_iter(1..=parameters.threshold);
 
         // Build SignData per party.
@@ -221,12 +221,12 @@ mod tests {
         };
         let session_id = rng::get_rng().random::<[u8; 32]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let data = SignData {
             sign_id: rng::get_rng().random::<[u8; 32]>().to_vec(),
             counterparties: vec![PartyIndex::new(2).unwrap()],
-            message_hash: hash("Message to sign!".as_bytes(), &[]),
+            message_hash: tagged_hash(b"test-sign", &["Message to sign!".as_bytes()]),
         };
 
         let (mut session, _) = SignSession::new(&parties[0], data).unwrap();

--- a/src/protocols/signing.rs
+++ b/src/protocols/signing.rs
@@ -947,7 +947,7 @@ mod tests {
         // We use the re_key function to quickly sample the parties.
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         // SIGNING
 
@@ -1107,7 +1107,7 @@ mod tests {
         // We use the re_key function to quickly sample the parties.
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         // SIGNING (as in test_signing)
 
@@ -1470,7 +1470,7 @@ mod tests {
                 Err(abort) => {
                     panic!("Party {} aborted: {:?}", abort.index, abort.description);
                 }
-                Ok(party) => {
+                Ok((party, _)) => {
                     parties.push(party);
                 }
             }
@@ -1633,7 +1633,7 @@ mod tests {
         };
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let data = SignData {
             sign_id: rng::get_rng()
@@ -1680,7 +1680,7 @@ mod tests {
         };
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let data = SignData {
             sign_id: rng::get_rng()
@@ -1731,7 +1731,7 @@ mod tests {
         };
         let session_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let secret_key = Scalar::random(&mut rng::get_rng());
-        let parties = re_key(&parameters, &session_id, &secret_key, None);
+        let (parties, _) = re_key(&parameters, &session_id, &secret_key, None);
 
         let sign_id = rng::get_rng().random::<[u8; crate::utilities::ID_LEN]>();
         let message_to_sign = hash("Message to sign!".as_bytes(), &[]);


### PR DESCRIPTION
# Issue 006: PublicKeyPackage Type
**Source**: local
**Issue ID**: 006
**Repo Root**: /home/fcc/Programming/DKLs23

## Problem
After the Distributed Key Generation (DKG) protocol completes (`src/protocols/dkg.rs`), the resulting `Party` struct contains the group public key (`pk`) and the participant's secret key share (`poly_point`), but there is no bundled public type that aggregates the group public key, per-participant verification shares, and threshold parameters. These verification shares are computed during DKG (`step5`) as `committed_points`, but are currently discarded after the consistency check. A `PublicKeyPackage` is required for signature aggregation verification, key derivation auditing, future share repair, and interoperability with `libtss`.

## Requirements
- The system shall define a `PublicKeyPackage` struct in `src/protocols.rs` containing `verifying_key` (`AffinePoint`), `verifying_shares` (`BTreeMap<PartyIndex, AffinePoint>`), and `parameters` (`Parameters`).