### PR TITLE
chore: bump dkls23-secp256k1 to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "dkls23-secp256k1"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bech32",
  "bs58",

--- a/dkls23-secp256k1/Cargo.toml
+++ b/dkls23-secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkls23-secp256k1"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — secp256k1 / Ethereum"


### PR DESCRIPTION
## Summary

- **dkls23-secp256k1**: `0.4.2` → `0.4.3` — patch bump for keccak pin relaxation (PR #80)
- **dkls23-core** and **dkls23-secp256r1**: unchanged (no code changes since v0.4.1)

## Test plan

- [x] `cargo check --workspace` passes
- [x] No code changes, only Cargo.toml version field and lock file