### PR TITLE
fix(ci): bump check-spelling to v0.0.26 for pull_request_target support

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ (contains(github.event_name, 'pull_request') && github.event.pull_request.state == 'open') || github.event_name == 'push' }}
         steps:
             - name: check-spelling
-              uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
+              uses: check-spelling/check-spelling@cfb6f7e75bbfc89c71eaa30366d0c166f1bd9c8c # v0.0.26
               with:
                   config: .github/actions/spelling
                   checkout: true


### PR DESCRIPTION
## Summary
- Bump check-spelling action from v0.0.25 to v0.0.26 — v0.0.25 does not support `pull_request_target` and rejects the configuration as unsafe

Follow-up to PR #85 which switched to `pull_request_target` but kept the old action version.

## Test plan
- [ ] Verify spell-check CI passes on this PR
- [ ] Re-trigger spell-check on PR #83 after merging