### PR TITLE
docs: add crate READMEs for crates.io and improve root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,61 +8,64 @@
     <a href="https://github.com/0xCarbon/DKLs23/actions?query=workflow%3Abackend-ci">
       <img src="https://github.com/0xCarbon/DKLs23/actions/workflows/backend-ci.yml/badge.svg?event=push" alt="Test Status">
     </a>
-    <a href="https://crates.io/crates/dkls23">
-      <img src="https://img.shields.io/crates/v/dkls23.svg" alt="DKLs23 Crate">
-    </a>
-    <a href="https://docs.rs/dkls23/latest/dkls23/">
-      <img src="https://docs.rs/dkls23/badge.svg" alt="DKLs23 Docs">
-    </a>
   </p>
 </div>
 
-<br /> 
-
 ## Overview
-DKLs23 is an advanced open-source implementation of the Threshold ECDSA method (see https://eprint.iacr.org/2023/765.pdf). The primary goal of DKLs23 is to compute a secret key without centralizing it in a single location. Instead, it leverages multiple parties to compute the secret key, with each party receiving a key share. This approach enhances security by eliminating single points of failure.
+
+DKLs23 is an open-source implementation of the [DKLs23 Threshold ECDSA protocol](https://eprint.iacr.org/2023/765.pdf). It computes ECDSA signatures across multiple parties, each holding a key share, without ever reconstructing the secret key in a single location.
+
+## Crates
+
+| Crate | Description | |
+|-------|-------------|---|
+| [`dkls23-core`](dkls23-core/) | Curve-generic core protocol | [![crates.io](https://img.shields.io/crates/v/dkls23-core.svg)](https://crates.io/crates/dkls23-core) |
+| [`dkls23-secp256k1`](dkls23-secp256k1/) | secp256k1 — Ethereum, Bitcoin, Cosmos, TRON | [![crates.io](https://img.shields.io/crates/v/dkls23-secp256k1.svg)](https://crates.io/crates/dkls23-secp256k1) |
+| [`dkls23-secp256r1`](dkls23-secp256r1/) | NIST P-256 — NEO3, Sui | [![crates.io](https://img.shields.io/crates/v/dkls23-secp256r1.svg)](https://crates.io/crates/dkls23-secp256r1) |
 
 ## libtss
 
-If you need session orchestration, transport, and resumable protocol flows, see [libtss](https://github.com/0xCarbon/libtss) — a higher-level library built on top of DKLs23 that handles multi-party communication and state management.
+For session orchestration, transport, and resumable protocol flows, see [libtss](https://github.com/0xCarbon/libtss) — a higher-level library built on top of DKLs23 that handles multi-party communication and state management.
 
 ## Getting Started
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
-### Installation
-A step-by-step guide to installing the project.
-
-1. **Install Rust using `rustup`**
-``` bash
+1. **Install Rust**
+```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-2. **Clone the repository:**
+2. **Add a dependency** (pick your curve)
 ```bash
-git clone https://github.com/0xCarbon/DKLs23 cd DKLs23
+cargo add dkls23-secp256k1   # or dkls23-secp256r1
 ```
 
-3. **Install dependencies:**
+3. **Clone for development**
 ```bash
-cargo build
+git clone https://github.com/0xCarbon/DKLs23
+cd DKLs23
+cargo test
 ```
 
 ## Contributing
+
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.
 
 ## Security
+
 For information on how to report security vulnerabilities, please see our [SECURITY.md](SECURITY.md).
 
 ## Code of Conduct
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+This project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to abide by its terms.
 
 ## License
-This project is licensed under either of
+
+Licensed under either of
 - [Apache License, Version 2.0](LICENSE-APACHE)
 - [MIT license](LICENSE-MIT)
 
 at your option.
 
 ## Authors
+
 See the list of [contributors](https://github.com/0xCarbon/DKLs23/contributors) who participated in this project.

--- a/dkls23-core/Cargo.toml
+++ b/dkls23-core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — curve-generic core"
 repository = "https://github.com/0xCarbon/DKLs23"
+readme = "README.md"
 
 [dependencies]
 elliptic-curve = { version = "0.14.0-rc.4", features = ["arithmetic", "sec1"] }

--- a/dkls23-core/Cargo.toml
+++ b/dkls23-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkls23-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — curve-generic core"

--- a/dkls23-core/README.md
+++ b/dkls23-core/README.md
@@ -1,0 +1,38 @@
+# dkls23-core
+
+[![Crates.io](https://img.shields.io/crates/v/dkls23-core.svg)](https://crates.io/crates/dkls23-core)
+[![docs.rs](https://docs.rs/dkls23-core/badge.svg)](https://docs.rs/dkls23-core)
+
+Curve-generic core implementation of the [DKLs23](https://eprint.iacr.org/2023/765.pdf) Threshold ECDSA protocol.
+
+This crate provides the cryptographic primitives and protocol logic for:
+
+- **Distributed Key Generation (DKG)** — generate key shares without a trusted dealer
+- **Threshold Signing** — produce ECDSA signatures with a subset of parties
+- **Key Refresh** — rotate key shares without changing the public key
+- **BIP-32 Derivation** — derive child keys from a master key share
+
+## Usage
+
+This is the curve-generic core — most users should depend on a curve-specific crate instead:
+
+- [`dkls23-secp256k1`](https://crates.io/crates/dkls23-secp256k1) — for Ethereum, Bitcoin, Cosmos, TRON
+- [`dkls23-secp256r1`](https://crates.io/crates/dkls23-secp256r1) — for NEO3, Sui
+
+Use `dkls23-core` directly only if you need to implement a custom curve via the `DklsCurve` trait.
+
+```toml
+[dependencies]
+dkls23-core = "0.5"
+```
+
+## API Levels
+
+- **High-level:** `DkgSession` and `SignSession` manage protocol state automatically
+- **Low-level:** `phase1`–`phase4` functions and keep-state types for advanced resumable/stateless orchestration
+
+For session orchestration, transport, and resumable flows, see [libtss](https://github.com/0xCarbon/libtss).
+
+## License
+
+Licensed under either of [Apache License 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) at your option.

--- a/dkls23-secp256k1/Cargo.toml
+++ b/dkls23-secp256k1/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — secp256k1 / Ethereum"
 repository = "https://github.com/0xCarbon/DKLs23"
+readme = "README.md"
 
 [dependencies]
 dkls23-core = { version = "0.5", path = "../dkls23-core" }

--- a/dkls23-secp256k1/Cargo.toml
+++ b/dkls23-secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkls23-secp256k1"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — secp256k1 / Ethereum"

--- a/dkls23-secp256k1/README.md
+++ b/dkls23-secp256k1/README.md
@@ -1,0 +1,42 @@
+# dkls23-secp256k1
+
+[![Crates.io](https://img.shields.io/crates/v/dkls23-secp256k1.svg)](https://crates.io/crates/dkls23-secp256k1)
+[![docs.rs](https://docs.rs/dkls23-secp256k1/badge.svg)](https://docs.rs/dkls23-secp256k1)
+
+[DKLs23](https://eprint.iacr.org/2023/765.pdf) Threshold ECDSA for the **secp256k1** curve, with address derivation for multiple blockchains.
+
+Built on [`dkls23-core`](https://crates.io/crates/dkls23-core) — provides concrete type aliases and chain-specific address computation.
+
+## Supported Chains
+
+| Chain | Function | Address Format |
+|-------|----------|----------------|
+| Ethereum (+ all EVM) | `compute_eth_address` | ERC-55 checksummed hex |
+| Bitcoin | `compute_btc_address` | P2WPKH Bech32 (`bc1q...`) |
+| Cosmos | `compute_cosmos_address` | Bech32 (configurable HRP) |
+| TRON | `compute_tron_address` | Base58Check (`T...`) |
+
+## Usage
+
+```toml
+[dependencies]
+dkls23-secp256k1 = "0.5"
+```
+
+## Features
+
+- `serde` (default) — serialization support for key shares and protocol messages
+- `insecure-rng` — deterministic RNG for testing (never use in production)
+
+## Protocol Overview
+
+- **Distributed Key Generation (DKG)** — generate key shares without a trusted dealer
+- **Threshold Signing** — produce ECDSA signatures with a subset of parties
+- **Key Refresh** — rotate key shares without changing the public key
+- **BIP-32 Derivation** — derive child keys from a master key share
+
+For session orchestration, transport, and resumable flows, see [libtss](https://github.com/0xCarbon/libtss).
+
+## License
+
+Licensed under either of [Apache License 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) at your option.

--- a/dkls23-secp256r1/Cargo.toml
+++ b/dkls23-secp256r1/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — secp256r1 / NEO3"
 repository = "https://github.com/0xCarbon/DKLs23"
+readme = "README.md"
 
 [dependencies]
 dkls23-core = { version = "0.5", path = "../dkls23-core" }

--- a/dkls23-secp256r1/Cargo.toml
+++ b/dkls23-secp256r1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkls23-secp256r1"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "DKLs23 Threshold ECDSA — secp256r1 / NEO3"

--- a/dkls23-secp256r1/README.md
+++ b/dkls23-secp256r1/README.md
@@ -1,0 +1,40 @@
+# dkls23-secp256r1
+
+[![Crates.io](https://img.shields.io/crates/v/dkls23-secp256r1.svg)](https://crates.io/crates/dkls23-secp256r1)
+[![docs.rs](https://docs.rs/dkls23-secp256r1/badge.svg)](https://docs.rs/dkls23-secp256r1)
+
+[DKLs23](https://eprint.iacr.org/2023/765.pdf) Threshold ECDSA for the **secp256r1 (NIST P-256)** curve, with address derivation for multiple blockchains.
+
+Built on [`dkls23-core`](https://crates.io/crates/dkls23-core) — provides concrete type aliases and chain-specific address computation.
+
+## Supported Chains
+
+| Chain | Function | Address Format |
+|-------|----------|----------------|
+| NEO3 | `compute_neo3_address` | Base58Check (`N...`) |
+| Sui | `compute_sui_address` | Hex (`0x...`) |
+
+## Usage
+
+```toml
+[dependencies]
+dkls23-secp256r1 = "0.5"
+```
+
+## Features
+
+- `serde` (default) — serialization support for key shares and protocol messages
+- `insecure-rng` — deterministic RNG for testing (never use in production)
+
+## Protocol Overview
+
+- **Distributed Key Generation (DKG)** — generate key shares without a trusted dealer
+- **Threshold Signing** — produce ECDSA signatures with a subset of parties
+- **Key Refresh** — rotate key shares without changing the public key
+- **BIP-32 Derivation** — derive child keys from a master key share
+
+For session orchestration, transport, and resumable flows, see [libtss](https://github.com/0xCarbon/libtss).
+
+## License
+
+Licensed under either of [Apache License 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) at your option.


### PR DESCRIPTION
## Summary
- Add per-crate `README.md` files with badges, usage, and supported chains table — these render on crates.io
- Add `readme = "README.md"` to each crate's `Cargo.toml`
- Root README: replace stale `dkls23` badges with per-crate badge table, improve getting started section
- Bump to v0.5.1 for crates.io re-publish with READMEs

## Test plan
- [ ] CI passes
- [ ] After publish, verify READMEs appear on crates.io