### PR TITLE
chore: deprecate dkls23 crate with redirect to new workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "dkls23",
     "dkls23-core",
     "dkls23-secp256k1",
     "dkls23-secp256r1",

--- a/dkls23/Cargo.toml
+++ b/dkls23/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dkls23"
+version = "0.3.1"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+description = "DEPRECATED — use dkls23-secp256k1 or dkls23-secp256r1 instead"
+repository = "https://github.com/0xCarbon/DKLs23"
+readme = "README.md"
+
+[dependencies]
+dkls23-secp256k1 = { version = "0.5", path = "../dkls23-secp256k1" }
+
+[features]
+default = ["serde"]
+serde = ["dkls23-secp256k1/serde"]
+insecure-rng = ["dkls23-secp256k1/insecure-rng"]

--- a/dkls23/README.md
+++ b/dkls23/README.md
@@ -1,0 +1,22 @@
+# dkls23
+
+> **This crate is deprecated.** It has been replaced by a multi-crate workspace:
+>
+> - [`dkls23-secp256k1`](https://crates.io/crates/dkls23-secp256k1) — secp256k1 with Ethereum, Bitcoin, Cosmos, TRON address derivation
+> - [`dkls23-secp256r1`](https://crates.io/crates/dkls23-secp256r1) — NIST P-256 with NEO3, Sui address derivation
+> - [`dkls23-core`](https://crates.io/crates/dkls23-core) — curve-generic core (use directly only for custom curves)
+
+## Migration
+
+Replace in your `Cargo.toml`:
+
+```diff
+- dkls23 = "0.3"
++ dkls23-secp256k1 = "0.5"
+```
+
+The API is compatible — `dkls23-secp256k1` re-exports everything from `dkls23-core` plus chain-specific address functions.
+
+## License
+
+Licensed under either of [Apache License 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) at your option.

--- a/dkls23/src/lib.rs
+++ b/dkls23/src/lib.rs
@@ -1,0 +1,6 @@
+#![deprecated(
+    since = "0.3.1",
+    note = "This crate is deprecated. Use `dkls23-secp256k1` for secp256k1/Ethereum/Bitcoin or `dkls23-secp256r1` for NIST P-256/NEO3/Sui."
+)]
+
+pub use dkls23_secp256k1::*;


### PR DESCRIPTION
## Summary
- Add `dkls23` v0.3.1 as a thin deprecated wrapper that re-exports `dkls23-secp256k1`
- `#![deprecated]` attribute triggers compiler warnings for users
- README on crates.io shows migration instructions pointing to the new crates
- Added to workspace members

## Test plan
- [x] `cargo check -p dkls23` compiles
- [ ] CI passes
- [ ] After merge, publish `dkls23` v0.3.1 to crates.io